### PR TITLE
增加 jsdelivr 下载链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,7 @@
 
 ## 下载链接
 * 手机进GitHub不好下载脚本的，可以进网盘下载
+* 自动更新
+下载 https://cdn.jsdelivr.net/gh/hyue418/taobao-11-11/
 * V2.1.0版
-下载:https://wws.lanzous.com/irXIQhqds7g 密码:f2bx
+下载: https://wws.lanzous.com/irXIQhqds7g 密码:f2bx


### PR DESCRIPTION
jsdelivr 为Github开源项目提供的CDN，自动跟随Github更新，可以减少作者频繁上传网盘的烦恼。
希望添加一下，更加方便了